### PR TITLE
increase text field size and support multiline

### DIFF
--- a/lib/pages/project_page/resource/resource_card.dart
+++ b/lib/pages/project_page/resource/resource_card.dart
@@ -32,6 +32,7 @@ class _ResourceCardState extends State<ResourceCard>
             Row(
               children: <Widget>[
                 Expanded(
+                  flex: 10,
                   child: Padding(
                     child: ResourceIdEditor(
                         resource: widget.resource,

--- a/lib/pages/project_page/resource/resurce_id_editor.dart
+++ b/lib/pages/project_page/resource/resurce_id_editor.dart
@@ -2,6 +2,7 @@ import 'package:arb/dart_arb.dart';
 import 'package:arb_editor/arb_bloc/arb_event.dart';
 import 'package:arb_editor/i18n/app_strings.dart';
 import 'package:flutter/material.dart';
+
 import '../../../utils.dart';
 
 class ResourceIdEditor extends StatelessWidget {
@@ -15,7 +16,7 @@ class ResourceIdEditor extends StatelessWidget {
     return TextFormField(
       initialValue: resource.id,
       onChanged: (newId) => updateId(context, newId),
-      maxLines: 1,
+      maxLines: null,
       style: Theme
           .of(context)
           .textTheme


### PR DESCRIPTION
The current text field for the locale resource id has display issue when the key names are long. Added flex to expand text field size and allow multiline.